### PR TITLE
resolve #23 (test specific contract)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import Echidna.Exec
 import Echidna.Solidity
 
 main :: IO ()
-main = do (v,a,ts) <- loadSolidity "test.sol"
+main = do (v,a,ts) <- loadSolidity "test.sol" Nothing
           let prop t = (PropertyName $ show t, ePropertySeq v a (`checkETest` t) 10)
           _ <- checkParallel . Group (GroupName "test.sol") $ map prop ts
           return ()

--- a/examples/revert/Revert.hs
+++ b/examples/revert/Revert.hs
@@ -11,7 +11,7 @@ import Echidna.Exec
 import Echidna.Solidity
 
 main :: IO ()
-main = do (v,a,ts) <- loadSolidity "solidity/revert.sol"
+main = do (v,a,ts) <- loadSolidity "solidity/revert.sol" Nothing
           let prop t = (PropertyName $ show t, ePropertySeq v a (`checkRTest` t) 10)
           _ <- checkParallel . Group (GroupName "revert.sol") $ map prop ts
           return ()

--- a/examples/state-machine/StateMachine.hs
+++ b/examples/state-machine/StateMachine.hs
@@ -74,7 +74,7 @@ prop_turnstile v = property $ do
 
 check_turnstile :: FilePath -> FilePath -> IO Bool
 check_turnstile dir fp = do putStrLn ("Checking " ++ fp ++ "...")
-                            (v,_,_) <- loadSolidity (dir ++ "/" ++ fp)
+                            (v,_,_) <- loadSolidity (dir ++ "/" ++ fp) Nothing
                             check (prop_turnstile v)
 
 main :: IO ()

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -11,6 +11,7 @@ import Control.Monad.State.Strict (execState, runState)
 import Data.Foldable              (toList)
 import Data.List                  (find, partition)
 import Data.Map                   ()
+import Data.Maybe                 (isNothing)
 import Data.Monoid                ((<>))
 import Data.Text                  (Text, isPrefixOf)
 import System.Process             (readProcess)
@@ -22,37 +23,46 @@ import EVM
   (VM, VMResult(..), contract, gas, loadContract, replaceCodeOfSelf, resetState, state)
 import EVM.Concrete (Blob(..))
 import EVM.Exec     (exec, vmForEthrunCreation)
-import EVM.Solidity (abiMap, contractName, creationCode, methodInputs, methodName, readSolc)
+import EVM.Solidity (abiMap, contractName, creationCode, methodInputs, methodName, readSolc, SolcContract)
 
 data EchidnaException = CompileFailure
                       | NoContracts
                       | TestArgsFound Text
+                      | ContractNotFound Text
 
 instance Show EchidnaException where
-  show CompileFailure    = "Couldn't compile given file"
-  show NoContracts       = "No contracts found in given file"
-  show (TestArgsFound t) = "Test " ++ show t ++ " has arguments, aborting"
+  show CompileFailure       = "Couldn't compile given file"
+  show NoContracts          = "No contracts found in given file"
+  show (ContractNotFound c) = "Given contract " ++ show c ++ " not found in given file"
+  show (TestArgsFound t)    = "Test " ++ show t ++ " has arguments, aborting"
 
 instance Exception EchidnaException
 
-loadSolidity :: (MonadIO m, MonadThrow m) => FilePath -> m (VM, [SolSignature], [Text])
-loadSolidity f = liftIO solc >>= \case
+selectContract :: (MonadThrow m) => [SolcContract] -> Maybe Text -> m SolcContract
+selectContract [] _ = throwM NoContracts
+selectContract (c:_) Nothing = return c
+selectContract cs (Just name) = case find (\x -> name == x ^. contractName) cs of
+  Nothing -> throwM $ ContractNotFound name
+  Just c  -> return c
+
+loadSolidity :: (MonadIO m, MonadThrow m) => FilePath -> Maybe Text -> m (VM, [SolSignature], [Text])
+loadSolidity f selectedContractName = liftIO solc >>= \case
   Nothing -> throwM CompileFailure
-  Just m  -> case toList $ fst m of
-    []     -> throwM NoContracts
-    (c:cs) -> do
-      warn (null cs) $
-        "Multiple contracts found in file, only analyzing the first (" <> c ^. contractName <> ")"
-      let (VMSuccess (B bc), vm) = runState exec . vmForEthrunCreation $ c ^. creationCode
-          load = do resetState
-                    assign (state . gas) 0xffffffffffffffff
-                    loadContract (vm ^. state . contract)
-          loaded = execState load $ execState (replaceCodeOfSelf bc) vm
-          abi = map (liftM2 (,) (view methodName) (map snd . view methodInputs)) . toList $ c ^. abiMap
-          (tests, funs) = partition (isPrefixOf "echidna_" . fst) abi
-      case find (not . null . snd) tests of
-        Nothing      -> return (loaded, funs, fst <$> tests)
-        (Just (t,_)) -> throwM $ TestArgsFound t
+  Just m  -> do
+    let cs = toList $ fst m
+    c <- selectContract cs selectedContractName
+    warn (isNothing selectedContractName && 1 < length cs) $
+      "Multiple contracts found in file, only analyzing the first (" <> c ^. contractName <> ")"
+    let (VMSuccess (B bc), vm) = runState exec . vmForEthrunCreation $ c ^. creationCode
+        load = do resetState
+                  assign (state . gas) 0xffffffffffffffff
+                  loadContract (vm ^. state . contract)
+        loaded = execState load $ execState (replaceCodeOfSelf bc) vm
+        abi = map (liftM2 (,) (view methodName) (map snd . view methodInputs)) . toList $ c ^. abiMap
+        (tests, funs) = partition (isPrefixOf "echidna_" . fst) abi
+    case find (not . null . snd) tests of
+      Nothing      -> return (loaded, funs, fst <$> tests)
+      (Just (t,_)) -> throwM $ TestArgsFound t
   where solc = readSolc =<< writeSystemTempFile "" =<< readProcess
           "solc" ["--combined-json=bin-runtime,bin,srcmap,srcmap-runtime,abi,ast", f] ""
-        warn p s = if p then pure () else liftIO $ print s
+        warn p s = if p then liftIO $ print s else pure ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -15,7 +15,7 @@ main :: IO ()
 main = getArgs >>= \case
   []  -> putStrLn "Please provide a solidity file to analyze"
   filepath:args -> do
-    (v,a,ts) <- loadSolidity filepath $ fmap pack $ listToMaybe args
+    (v,a,ts) <- loadSolidity filepath $ pack <$> listToMaybe args
     let prop t = (PropertyName $ show t, ePropertySeq v a (`checkETest` t) 10)
     _ <- checkParallel . Group (GroupName filepath) $ map prop ts
     return ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,6 +5,8 @@ module Main where
 import Hedgehog hiding (checkParallel)
 import Hedgehog.Internal.Property (GroupName(..), PropertyName(..))
 import System.Environment         (getArgs)
+import Data.Maybe (listToMaybe)
+import Data.Text (pack)
 
 import Echidna.Exec
 import Echidna.Solidity
@@ -12,8 +14,8 @@ import Echidna.Solidity
 main :: IO ()
 main = getArgs >>= \case
   []  -> putStrLn "Please provide a solidity file to analyze"
-  f:_ -> do
-    (v,a,ts) <- loadSolidity f
+  filepath:args -> do
+    (v,a,ts) <- loadSolidity filepath $ fmap pack $ listToMaybe args
     let prop t = (PropertyName $ show t, ePropertySeq v a (`checkETest` t) 10)
-    _ <- checkParallel . Group (GroupName f) $ map prop ts
+    _ <- checkParallel . Group (GroupName filepath) $ map prop ts
     return ()


### PR DESCRIPTION
- resolved #23 
- extracted contract selection into function `selectContract` because `loadSolidity` became unwieldy otherwise
- made `warn` print warning if predicate is true (instead of false) which makes more sense imho

works as expected with contracts in multiple files and imports