### PR TITLE
Extended support to generate and execute more transaction fields (msg.value, msg.sender, ..)

### DIFF
--- a/examples/revert/Revert.hs
+++ b/examples/revert/Revert.hs
@@ -17,6 +17,6 @@ main = do (v,a,ts) <- loadSolidity "solidity/revert.sol" Nothing
           return ()
 
 checkRTest :: VM -> Text -> Bool
-checkRTest v t = case evalState (execCall (t, [])) v of
+checkRTest v t = case evalState (execCall (t, [], 0, 0)) v of
   (VMFailure Revert) -> False
   _                  -> True

--- a/examples/state-machine/StateMachine.hs
+++ b/examples/state-machine/StateMachine.hs
@@ -37,7 +37,7 @@ instance HTraversable Push where
 -- commands representing state transitions that are passed to hedgehog
 s_coin :: (Monad n, MonadTest m, MonadState VM m) => Command n m ModelState
 s_coin = Command (\_ -> Just $ pure Coin)
-  (\Coin -> execCall ("coin", []))
+  (\Coin -> execCall ("coin", [], 0, 0))
   [ Update $ \_ Coin _ -> TUnlocked
   , Ensure $ \_ s Coin _ -> s === TUnlocked
   ]
@@ -48,7 +48,7 @@ match _ _ = False
 
 s_push_locked :: (Monad n, MonadTest m, MonadState VM m) => Command n m ModelState
 s_push_locked = Command (\s -> if s == TLocked then Just $ pure Push else Nothing)
-  (\Push -> execCall ("push", []))
+  (\Push -> execCall ("push", [], 0, 0))
   [ Require $ \s Push -> s == TLocked
   , Update $ \_ Push _ -> TLocked 
   , Ensure $ \before after Push b -> do before === TLocked
@@ -58,7 +58,7 @@ s_push_locked = Command (\s -> if s == TLocked then Just $ pure Push else Nothin
 
 s_push_unlocked :: (Monad n, MonadTest m, MonadState VM m) => Command n m ModelState
 s_push_unlocked = Command (\s -> if s == TUnlocked then Just $ pure Push else Nothing)
-  (\Push -> execCall ("push", []))
+  (\Push -> execCall ("push", [], 0, 0))
   [ Require $ \s Push -> s == TUnlocked
   , Update $ \_ Push _ -> TLocked 
   , Ensure $ \before after Push b -> do before === TUnlocked


### PR DESCRIPTION
**This PR is an early prototype for discussion. Not intended to merge it soon.**

Echidna should be able to handle the generation of all the transaction data fields to trigger deep parts of a contract code (for instance, code depending on msg.value or msg.sender). This PR allows to generate and execute them (so, it should fix #30 when it is ready) so echidna can find a failed test in this small example:

```solidity
contract C {

  uint state = 0;
  function f() payable {
    if (msg.value > 128)
        state = msg.value;
  }

  function echidna_test() returns (bool) {
    return(state == 0);
  }
}
```

It outputs:

```bash
  ✗ "echidna_test" failed after 5 tests and 5 shrinks.
  
      │ Call sequence: f() paying 129;
  
  ✗ 1 failed.
```