### PR TITLE
Enabling Syntax Highlighting for Solidity Files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
The Echidna repo currently lacks solidity syntax highlighting for its example contracts. Github recently added on support for this type of highlighting, but requires the addition of a `.gitattributes` file to enable it. This PR adds such a file to Echidna.