### PR TITLE
Dev evm config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ For each unit test it finds, it will execute a fuzzing campaign to try and find 
 An example contract with tests can be found [solidity/cli.sol](solidity/cli.sol)
 `echidna-test solidity/cli.sol` should find a call sequence such that `echidna_sometimesfalse` fails, but be unable to do so for `echidna_alwaystrue`.
 
-Echidna can be customized with a variety of command line arguments. Users can pass options command line arguments to choose the contract to test, turn on coverage guided testing, and load a configuration file
+Echidna can be customized with a variety of command line arguments. Users can pass optional command line arguments to choose the contract to test, turn on coverage guided testing, and load a configuration file. For example:
 ```
-echidna-test FILE CONTRACT --coverage --config=CONFIG
+echidna-test solidity/cli.sol solidity/cli.sol:Test --coverage --config="solidity/config.yaml"
 ```
 The configuration file allows users to choose various EVM and test generation parameters within Echidna and is in yaml format. An example config file, along with documentation, can be found at [solidity/config.yaml](solidity/config.yaml)
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ For each unit test it finds, it will execute a fuzzing campaign to try and find 
 An example contract with tests can be found [solidity/cli.sol](solidity/cli.sol)
 `echidna-test solidity/cli.sol` should find a call sequence such that `echidna_sometimesfalse` fails, but be unable to do so for `echidna_alwaystrue`.
 
-Support for multiple contracts in a single file along with importing files from an unsupported directory has bee added by using the following optional command line arguments:
+Echidna can be customized with a variety of command line arguments. Users can pass options command line arguments to choose the contract to test, turn on coverage guided testing, and load a configuration file
 ```
-echidna-test solidity/cli.sol Test2 --solc-args="--allow-paths=/echidna/solidity"
+echidna-test FILE CONTRACT --coverage --config=CONFIG
 ```
+The configuration file allows users to choose various EVM and test generation parameters within Echidna and is in yaml format. An example config file, along with documentation, can be found at [solidity/config.yaml](solidity/config.yaml)
 
 ## Usage (as a library)
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Echidna builds an executable, `echidna-test` that can be used from the command l
 It expects unit tests in the form of functions with names starting with `echidna_` that take no arguments and return a `bool` indicating success or failure.
 For each unit test it finds, it will execute a fuzzing campaign to try and find a set of calls such that executing that call sequence, then the test either returns `false` or results in a VM failure.
 
-An example contract with tests can be found [solidity/cli.sol](solidity/cli.sol)
+An example contract with tests can be found [solidity/cli.sol](solidity/cli.sol). Running
 `echidna-test solidity/cli.sol` should find a call sequence such that `echidna_sometimesfalse` fails, but be unable to do so for `echidna_alwaystrue`.
 
 Echidna can be customized with a variety of command line arguments. Users can pass optional command line arguments to choose the contract to test, turn on coverage guided testing, and load a configuration file. For example:
 ```
 echidna-test solidity/cli.sol solidity/cli.sol:Test --coverage --config="solidity/config.yaml"
 ```
-The configuration file allows users to choose various EVM and test generation parameters within Echidna and is in yaml format. An example config file, along with documentation, can be found at [solidity/config.yaml](solidity/config.yaml)
+The configuration file allows users to choose various EVM and test generation parameters within Echidna and is in yaml format. An example config file, along with documentation, can be found at [solidity/config.yaml](solidity/config.yaml).
 
 ## Usage (as a library)
 

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -209,7 +209,7 @@ mutateValue (AbiUInt s n) =
   newOrMod (genAbiUInt s)         (AbiUInt s)         (changeNumber n)
 mutateValue (AbiInt s n) =
   newOrMod (genAbiInt s)          (AbiInt s)          (changeNumber n)
-mutateValue (AbiAddress a) = do
+mutateValue (AbiAddress a) =
   newOrMod genAbiAddress          AbiAddress          (changeNumber a)
 mutateValue (AbiBool _) = genAbiBool
 mutateValue (AbiBytes s b) =

--- a/lib/Echidna/ABI.hs
+++ b/lib/Echidna/ABI.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, RankNTypes, TupleSections, TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds, FlexibleContexts, RankNTypes, TupleSections, TypeFamilies #-}
 
 module Echidna.ABI (
     SolCall
@@ -24,8 +24,9 @@ module Echidna.ABI (
   , prettyPrint
 ) where
 
-import Control.Lens          ((<&>), (&))
+import Control.Lens          ((<&>), (&), view)
 import Control.Monad         (join, liftM2, replicateM)
+import Control.Monad.Reader  (MonadReader, asks, runReaderT)
 import Data.Bool             (bool)
 import Data.DoubleWord       (Word128(..), Word160(..))
 import Data.Monoid           ((<>))
@@ -42,8 +43,10 @@ import qualified Data.List       as L
 import qualified Data.Text       as T
 import qualified Hedgehog.Gen    as Gen
 
+import Echidna.Config (Config, addrList)
+
 import EVM.ABI
-import EVM.Types ()
+import EVM.Types (Addr(..))
 
 type SolCall = (Text, [AbiValue])
 
@@ -68,8 +71,9 @@ encodeSig n ts = n <> "(" <> T.intercalate "," (map abiTypeSolidity ts) <> ")"
 genSize :: MonadGen m => m Int
 genSize = (8 *) <$> Gen.enum 1 32
 
-genAbiAddress :: MonadGen m => m AbiValue
-genAbiAddress = let w64 = Gen.word64 $ constant minBound maxBound in
+genAbiAddress :: MonadGen m => Maybe [Addr] -> m AbiValue
+genAbiAddress (Just xs) = fmap (AbiAddress . addressWord160) (Gen.element xs)
+genAbiAddress _ = let w64 = Gen.word64 $ constant minBound maxBound in
   fmap AbiAddress . liftM2 Word160 Gen.enumBounded $ liftM2 Word128 w64 w64
 
 genAbiUInt :: MonadGen m => Int -> m AbiValue
@@ -109,26 +113,26 @@ genAbiType = Gen.choice [ pure AbiBytesDynamicType
                         , genStaticAbiType
                         ]
 
-genVecOfType :: MonadGen m => AbiType -> Range Int -> m (Vector AbiValue)
+genVecOfType :: (MonadReader Config m, MonadGen m) => AbiType -> Range Int -> m (Vector AbiValue)
 genVecOfType t r = fmap fromList . Gen.list r $ case t of
   AbiUIntType    n    -> genAbiUInt n
   AbiIntType     n    -> genAbiInt n
-  AbiAddressType      -> genAbiAddress
+  AbiAddressType      -> genAbiAddress =<< asks (view addrList)
   AbiBoolType         -> genAbiBool
   AbiBytesType   n    -> genAbiBytes n
   AbiArrayType   n t' -> genAbiArray n t'
   _ -> error "Arrays must only contain statically sized types"
 
-genAbiArrayDynamic :: MonadGen m => AbiType -> m AbiValue
+genAbiArrayDynamic :: (MonadReader Config m, MonadGen m) => AbiType -> m AbiValue
 genAbiArrayDynamic t = AbiArrayDynamic t <$> genVecOfType t (constant 0 256)
 
-genAbiArray :: MonadGen m => Int -> AbiType -> m AbiValue
+genAbiArray :: (MonadReader Config m, MonadGen m) => Int -> AbiType -> m AbiValue
 genAbiArray n t = AbiArray n t <$> genVecOfType t (singleton n)
 
-genAbiValue :: MonadGen m => m AbiValue
+genAbiValue :: (MonadReader Config m, MonadGen m) => m AbiValue
 genAbiValue = Gen.choice [ genAbiUInt =<< genSize
                          , genAbiInt =<< genSize
-                         , genAbiAddress
+                         , genAbiAddress =<< asks (view addrList)
                          , genAbiBool
                          , genAbiBytes =<< Gen.enum 1 32
                          , genAbiBytesDynamic
@@ -137,11 +141,11 @@ genAbiValue = Gen.choice [ genAbiUInt =<< genSize
                          , join $ liftM2 genAbiArray (Gen.enum 0 256) genAbiType
                          ]
 
-genAbiValueOfType :: MonadGen m => AbiType -> m AbiValue
+genAbiValueOfType :: (MonadReader Config m, MonadGen m) => AbiType -> m AbiValue
 genAbiValueOfType t = case t of
   AbiUIntType n          -> genAbiUInt n
   AbiIntType  n          -> genAbiInt n
-  AbiAddressType         -> genAbiAddress
+  AbiAddressType         -> genAbiAddress =<< asks (view addrList)
   AbiBoolType            -> genAbiBool
   AbiBytesType n         -> genAbiBytes n
   AbiBytesDynamicType    -> genAbiBytesDynamic
@@ -149,7 +153,7 @@ genAbiValueOfType t = case t of
   AbiArrayDynamicType t' -> genAbiArrayDynamic t'
   AbiArrayType n t'      -> genAbiArray n t'
 
-genAbiCall :: MonadGen m => SolSignature -> m SolCall
+genAbiCall :: (MonadReader Config m, MonadGen m) => SolSignature -> m SolCall
 genAbiCall (s,ts) = (s,) <$> mapM genAbiValueOfType ts
 
 encodeAbiCall :: SolCall -> ByteString
@@ -160,8 +164,8 @@ displayAbiCall (t, vs) = unpack t ++ "(" ++ L.intercalate "," (map prettyPrint v
 
 -- genInteractions generates a function call from a list of type signatures of
 -- the form (Function name, [arg0 type, arg1 type...])
-genInteractions :: MonadGen m => [SolSignature] -> m SolCall
-genInteractions ls = genAbiCall =<< Gen.element ls
+genInteractions :: MonadGen m => [SolSignature] -> Config -> m SolCall
+genInteractions ls c = runReaderT (genAbiCall =<< Gen.element ls) c
 
 type Listy t a = (IsList (t a), Item (t a) ~ a)
 
@@ -196,16 +200,17 @@ changeList g0 g1 x = let l = toList x in
              , switchElem g1 l
              ] <&> fromList
 
-newOrMod :: MonadGen m => m AbiValue -> (a -> AbiValue) -> m a -> m AbiValue
+newOrMod ::  MonadGen m => m AbiValue -> (a -> AbiValue) -> m a -> m AbiValue
 newOrMod m f n = Gen.choice [m, f <$> n]
 
-mutateValue :: MonadGen m => AbiValue -> m AbiValue
+mutateValue :: (MonadReader Config m, MonadGen m) => AbiValue -> m AbiValue
 mutateValue (AbiUInt s n) =
   newOrMod (genAbiUInt s)         (AbiUInt s)         (changeNumber n)
 mutateValue (AbiInt s n) =
   newOrMod (genAbiInt s)          (AbiInt s)          (changeNumber n)
-mutateValue (AbiAddress a) =
-  newOrMod genAbiAddress          AbiAddress          (changeNumber a)
+mutateValue (AbiAddress a) = do
+  addr <- asks (view addrList)
+  newOrMod (genAbiAddress addr)   AbiAddress          (changeNumber a)
 mutateValue (AbiBool _) = genAbiBool
 mutateValue (AbiBytes s b) =
   newOrMod (genAbiBytes s)        (AbiBytes s)        (changeChar b)
@@ -221,9 +226,9 @@ mutateValue (AbiArray s t a) =
 changeOrId :: (Traversable t, MonadGen m) => (a -> m a) -> t a -> m (t a)
 changeOrId f = mapM $ (Gen.element [f, pure] >>=) . (&)
 
-mutateCall :: MonadGen m => SolCall -> m SolCall
-mutateCall (t, vs) = (t,) <$> changeOrId mutateValue vs
+mutateCall :: MonadGen m => Config -> SolCall -> m SolCall
+mutateCall c (t, vs) = runReaderT ((t,) <$> changeOrId mutateValue vs) c
 
-mutateCallSeq :: MonadGen m => [SolSignature] -> [SolCall] -> m [SolCall]
-mutateCallSeq s cs = let g = genInteractions s in
-  changeOrId mutateCall cs >>= changeList (Gen.element [1..10] >>= flip replicateM g) g
+mutateCallSeq :: MonadGen m => [SolSignature] -> [SolCall] -> Config -> m [SolCall]
+mutateCallSeq s cs c = let g = genInteractions s c in
+  changeOrId (mutateCall c) cs >>= changeList (Gen.element [1..10] >>= flip replicateM g) g

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -13,28 +13,38 @@ import GHC.Generics
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Yaml as Y
 
-import EVM.Types (W256)
+import EVM.Types (Addr, W256)
 
 
 data Config = Config
-  { _solcArgs :: Maybe String
-  , _epochs :: Int
-  , _testLimit :: Int
-  , _range :: Int
-  , _gasLimit :: W256 }
+  { _solcArgs     :: Maybe String
+  , _epochs       :: Int
+  , _testLimit    :: Int
+  , _range        :: Int
+  , _gasLimit     :: W256
+  , _contractAddr :: Addr
+  , _sender       :: Addr }
   deriving (Show, Generic)
 
 makeLenses ''Config
 
 instance FromJSON Config
 
+defaultContractAddr :: Addr
+defaultContractAddr = 0x00a329c0648769a73afac7f9381e08fb43dbea72
+
+defaultSender :: Addr
+defaultSender = 0x00a329c0648769a73afac7f9381e08fb43dbea70
+
 defaultConfig :: Config
 defaultConfig = Config
-  { _solcArgs = Nothing
-  , _epochs = 2
-  , _testLimit = 10000
-  , _range = 10
-  , _gasLimit = 0xffffffffffffffff }
+  { _solcArgs     = Nothing
+  , _epochs       = 2
+  , _testLimit    = 10000
+  , _range        = 10
+  , _gasLimit     = 0xffffffffffffffff
+  , _contractAddr = defaultContractAddr
+  , _sender       = defaultSender }
 
 withDefaultConfig :: ReaderT Config m a -> m a
 withDefaultConfig = (flip runReaderT) defaultConfig

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -12,21 +12,21 @@ import Data.Aeson
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Yaml as Y
 
-import EVM.Types (Addr, W256)
+import Echidna.Property (PropertyType(..))
 
-import Echidna.Property
+import EVM.Types (Addr, W256)
 
 data Config = Config
   { _solcArgs     :: Maybe String
   , _epochs       :: Int
   , _testLimit    :: Int
   , _range        :: Int
-  , _gasLimit     :: W256
   , _contractAddr :: Addr
   , _sender       :: Addr
-  , _addrList     :: Maybe [Addr] }
+  , _addrList     :: Maybe [Addr]
   , _gasLimit     :: W256 
   , _shrinkLimit  :: W256 
+  , _returnType   :: PropertyType
   }
   deriving Show
 
@@ -37,12 +37,12 @@ instance FromJSON Config where
                                 <*> v .:? "epochs"       .!= 2
                                 <*> v .:? "testLimit"    .!= 10000
                                 <*> v .:? "range"        .!= 10
-                                <*> v .:? "gasLimit"     .!= 0xffffffffffffffff 
                                 <*> v .:? "contractAddr" .!= 0x00a329c0648769a73afac7f9381e08fb43dbea72
                                 <*> v .:? "sender"       .!= 0x00a329c0648769a73afac7f9381e08fb43dbea70
                                 <*> v .:? "addrList"     .!= Nothing
                                 <*> v .:? "gasLimit"     .!= 0xffffffffffffffff
                                 <*> v .:? "shrinkLimit"  .!= 1000 
+                                <*> v .:? "return"       .!= ShouldReturnTrue
   parseJSON _          = parseJSON (Object mempty)
 
 newtype ParseException = ParseException FilePath

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -35,7 +35,7 @@ instance FromJSON Config where
                                 <*> v .:? "gasLimit"     .!= 0xffffffffffffffff 
                                 <*> v .:? "contractAddr" .!= 0x00a329c0648769a73afac7f9381e08fb43dbea72
                                 <*> v .:? "sender"       .!= 0x00a329c0648769a73afac7f9381e08fb43dbea70
-                                <*> v .:? "addrList" .   .!= Nothing
+                                <*> v .:? "addrList"     .!= Nothing
   parseJSON _          = parseJSON (Object mempty)
 
 newtype ParseException = ParseException FilePath

--- a/lib/Echidna/Config.hs
+++ b/lib/Echidna/Config.hs
@@ -23,12 +23,16 @@ data Config = Config
   , _range        :: Int
   , _gasLimit     :: W256
   , _contractAddr :: Addr
-  , _sender       :: Addr }
+  , _sender       :: Addr
+  , _addrList     :: Maybe [Addr] }
   deriving (Show, Generic)
 
 makeLenses ''Config
 
 instance FromJSON Config
+
+------------------------------------
+-- Defaults
 
 defaultContractAddr :: Addr
 defaultContractAddr = 0x00a329c0648769a73afac7f9381e08fb43dbea72
@@ -44,10 +48,15 @@ defaultConfig = Config
   , _range        = 10
   , _gasLimit     = 0xffffffffffffffff
   , _contractAddr = defaultContractAddr
-  , _sender       = defaultSender }
+  , _sender       = defaultSender
+  , _addrList     = Nothing }
 
 withDefaultConfig :: ReaderT Config m a -> m a
 withDefaultConfig = (flip runReaderT) defaultConfig
+
+
+------------------------------------
+-- Parser
 
 data ParseException = ParseException FilePath
 

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -11,21 +11,18 @@ module Echidna.Exec (
   , ePropertySeqCoverage
   , execCall
   , execCallCoverage
-  , fuzz
   , getCover
   , module Echidna.Internal.Runner
   ) where
 
 import Control.Concurrent.MVar    (MVar, modifyMVar_)
 import Control.Lens               ((^.), (.=), use)
-import Control.Monad              (forM_, replicateM)
 import Control.Monad.Catch        (MonadCatch)
 import Control.Monad.IO.Class     (MonadIO, liftIO)
 import Control.Monad.State.Strict (MonadState, StateT, evalState, evalStateT, execState, get, put, runState)
 import Control.Monad.Reader       (MonadReader, ReaderT, runReaderT, ask)
 import Data.IORef                 (IORef, modifyIORef', newIORef, readIORef)
 import Data.List                  (intercalate, foldl')
-import Data.Maybe                 (listToMaybe)
 import Data.Ord                   (comparing)
 import Data.Set                   (Set, empty, insert, size, union)
 import Data.Text                  (Text)
@@ -37,7 +34,7 @@ import qualified Data.Vector.Mutable as M
 import qualified Data.Vector as V
 
 import Hedgehog
-import Hedgehog.Gen               (sample, sequential)
+import Hedgehog.Gen               (sequential)
 import Hedgehog.Internal.State    (Action(..))
 import Hedgehog.Internal.Property (PropertyConfig(..), mapConfig)
 import Hedgehog.Range             (linear)
@@ -107,21 +104,6 @@ execCallCoverage sol = execCallUsing (go empty) sol where
 -------------------------------------------------------------------
 -- Fuzzing and Hedgehog Init
 
-fuzz :: MonadIO m
-     => Config              -- Echidna configuration
-     -> Int                 -- Call sequence length
-     -> Int                 -- Number of iterations
-     -> [SolSignature]      -- Type signatures to call
-     -> VM                  -- Initial state
-     -> (VM -> m Bool)      -- Predicate to fuzz for violations of
-     -> m (Maybe [SolCall]) -- Call sequence to violate predicate (if found)
-fuzz c l n ts v p = do
-  callseqs <- replicateM n (replicateM l . sample $ (genInteractions ts c))
-  results <- zip callseqs <$> mapM run callseqs
-  return $ listToMaybe [cs | (cs, passed) <- results, not passed]
-    where run cs = p $ execState (forM_ cs execCall) v
-
-
 checkETest :: VM -> Text -> Bool
 checkETest v t = case evalState (execCall (t, [])) v of
   VMSuccess (B s) -> s == encodeAbiValue (AbiBool True)
@@ -161,9 +143,9 @@ eCommand = flip eCommandUsing (\ _ -> pure ())
 
 eCommandCoverage :: (MonadGen n, MonadTest m, MonadState VM m, MonadReader CoverageRef m, MonadIO m)
                  => [SolCall] -> (VM -> Bool) -> [SolSignature] -> Config -> [Command n m VMState]
-eCommandCoverage cov p ts conf = case cov of
-  [] -> [eCommandUsing (genInteractions ts conf) (\(Call c) -> execCallCoverage c) p]
-  xs -> map (\x -> eCommandUsing (mutateCall conf x)
+eCommandCoverage cov p ts conf = let useConf = flip runReaderT conf in case cov of
+  [] -> [eCommandUsing (useConf $ genInteractions ts) (\(Call c) -> execCallCoverage c) p]
+  xs -> map (\x -> eCommandUsing (useConf $ mutateCall x)
               (\(Call c) -> execCallCoverage c) p) xs
 
 ePropertyUsing :: (MonadCatch m, MonadTest m, MonadReader Config n)
@@ -186,7 +168,7 @@ ePropertySeq :: (MonadReader Config m)
              -> [SolSignature] -- Type signatures to fuzz
              -> VM             -- Initial state
              -> m Property
-ePropertySeq p ts vm = ask >>= \c -> ePropertyUsing [eCommand (genInteractions ts c) p] id vm
+ePropertySeq p ts vm = ask >>= \c -> ePropertyUsing [eCommand (runReaderT (genInteractions ts) c) p] id vm
 
 
 ePropertySeqCoverage :: (MonadReader Config m)

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -37,7 +37,7 @@ import qualified Data.Vector.Mutable as M
 import qualified Data.Vector as V
 
 import Hedgehog
-import Hedgehog.Gen               (choice, sample, sequential)
+import Hedgehog.Gen               (sample, sequential)
 import Hedgehog.Internal.State    (Action(..))
 import Hedgehog.Internal.Property (PropertyConfig(..), mapConfig)
 import Hedgehog.Range             (linear)
@@ -108,14 +108,15 @@ execCallCoverage sol = execCallUsing (go empty) sol where
 -- Fuzzing and Hedgehog Init
 
 fuzz :: MonadIO m
-     => Int                 -- Call sequence length
+     => Config              -- Echidna configuration
+     -> Int                 -- Call sequence length
      -> Int                 -- Number of iterations
      -> [SolSignature]      -- Type signatures to call
      -> VM                  -- Initial state
      -> (VM -> m Bool)      -- Predicate to fuzz for violations of
      -> m (Maybe [SolCall]) -- Call sequence to violate predicate (if found)
-fuzz l n ts v p = do
-  callseqs <- replicateM n (replicateM l . sample $ genInteractions ts)
+fuzz c l n ts v p = do
+  callseqs <- replicateM n (replicateM l . sample $ (genInteractions ts c))
   results <- zip callseqs <$> mapM run callseqs
   return $ listToMaybe [cs | (cs, passed) <- results, not passed]
     where run cs = p $ execState (forM_ cs execCall) v
@@ -159,10 +160,10 @@ eCommand = flip eCommandUsing (\ _ -> pure ())
 
 
 eCommandCoverage :: (MonadGen n, MonadTest m, MonadState VM m, MonadReader CoverageRef m, MonadIO m)
-                 => [SolCall] -> (VM -> Bool) -> [SolSignature] -> [Command n m VMState]
-eCommandCoverage cov p ts = case cov of
-  [] -> [eCommandUsing (genInteractions ts) (\(Call c) -> execCallCoverage c) p]
-  xs -> map (\x -> eCommandUsing (choice [mutateCall x, genInteractions ts])
+                 => [SolCall] -> (VM -> Bool) -> [SolSignature] -> Config -> [Command n m VMState]
+eCommandCoverage cov p ts conf = case cov of
+  [] -> [eCommandUsing (genInteractions ts conf) (\(Call c) -> execCallCoverage c) p]
+  xs -> map (\x -> eCommandUsing (mutateCall conf x)
               (\(Call c) -> execCallCoverage c) p) xs
 
 ePropertyUsing :: (MonadCatch m, MonadTest m, MonadReader Config n)
@@ -185,7 +186,7 @@ ePropertySeq :: (MonadReader Config m)
              -> [SolSignature] -- Type signatures to fuzz
              -> VM             -- Initial state
              -> m Property
-ePropertySeq p ts = ePropertyUsing [eCommand (genInteractions ts) p] id             
+ePropertySeq p ts vm = ask >>= \c -> ePropertyUsing [eCommand (genInteractions ts c) p] id vm
 
 
 ePropertySeqCoverage :: (MonadReader Config m)
@@ -195,7 +196,7 @@ ePropertySeqCoverage :: (MonadReader Config m)
                      -> [SolSignature]
                      -> VM
                      -> m Property
-ePropertySeqCoverage calls cov p ts v = ePropertyUsing (eCommandCoverage calls p ts) writeCoverage v 
+ePropertySeqCoverage calls cov p ts v = ask >>= \c -> ePropertyUsing (eCommandCoverage calls p ts c) writeCoverage v 
   where writeCoverage :: MonadIO m => ReaderT CoverageRef (StateT VM m) a -> m a
         writeCoverage m = do
           threadCovRef <- liftIO $ newIORef mempty

--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -145,7 +145,7 @@ eCommandCoverage :: (MonadGen n, MonadTest m, MonadState VM m, MonadReader Cover
                  => [SolCall] -> (VM -> Bool) -> [SolSignature] -> Config -> [Command n m VMState]
 eCommandCoverage cov p ts conf = let useConf = flip runReaderT conf in case cov of
   [] -> [eCommandUsing (useConf $ genInteractions ts) (\(Call c) -> execCallCoverage c) p]
-  xs -> map (\x -> eCommandUsing (choice [mutateCall x, genInteractions ts])
+  xs -> map (\x -> eCommandUsing (choice $ useConf <$> [mutateCall x, genInteractions ts])
               (\(Call c) -> execCallCoverage c) p) xs
 
 

--- a/lib/Echidna/Solidity.hs
+++ b/lib/Echidna/Solidity.hs
@@ -22,7 +22,7 @@ import System.IO.Temp             (writeSystemTempFile)
 import qualified Data.Map as Map (lookup)
 
 import Echidna.ABI    (SolSignature)
-import Echidna.Config (Config(..), sender, contractAddr, gasLimit, solcArgs, defaultConfig)
+import Echidna.Config (Config(..), sender, contractAddr, gasLimit, solcArgs)
 
 
 import EVM

--- a/solidity/config.yaml
+++ b/solidity/config.yaml
@@ -1,4 +1,16 @@
+#Arguments to solc
+#_solcArgs:
+#Choose the number of epochs to use in coverage-guided testing
 _epochs: 2
+#Set the gas limit for each test
 _gasLimit: 0xfffff
+#Number of tests that will run for each property
 _testLimit: 10000
+#Honestly not sure what this is
 _range: 10
+#Contract's address in the EVM
+_contractAddr: 0x00a329c0648769a73afac7f9381e08fb43dbea72
+#Sender's address in the EVM
+_sender: 0x00a329c0648769a73afac7f9381e08fb43dbea70
+#List of addresses that will be used in all tests
+#_addrList:


### PR DESCRIPTION
Added functionality for specifying the contract address and `sender` in the EVM during Echidna tests. Also added functionality for whitelisting a list of addresses that will be chosen from during test generation. 

It may be good to have a list of potential `sender`'s instead of a fixed `sender`. Another potential improvement would be to let users simply specify the number of unique addresses they want Echidna to use in test generation (which would make life easier if users wanted 50 addresses to be used). We could even have Echidna print the list of addresses it generated. Both of these would be minor fixes, though.

