### PR TITLE
update doc about installing solc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Before starting with it, make sure you have libgmp-dev installed otherwise ghc w
 
 [solc](https://www.npmjs.com/package/solc) is another echidna dependency not handled via stack.
 It is technically optional, but working with solidity source will fail without it.
-Run `npm install -g solc` to install it.
+Install `solc` following the [official document](https://solidity.readthedocs.io/en/v0.4.24/installing-solidity.html).
+Note that `solc` must be installed by any method other than `npm / Node.js`.
 
 Once solc is installed, installing stack (`brew install haskell-stack`) and running
 


### PR DESCRIPTION
This PR updates the document about installing `solc`

Installing `solc` by `npm install -g solc` creates a binary called `solcjs` but not `solc`. Hence calling `echidna-test` will fail. 

For example:
```
npm install -g solc
echidna-test solidity/cli.sol
echidna-test: solc: readCreateProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
```

**Fix**
Install `solc` following the instruction, found in the [official doc](https://solidity.readthedocs.io/en/v0.4.24/installing-solidity.html#), by any method other than `npm install -g solc`