### PR TITLE
Save corpus of unique transactions according to coverage

### DIFF
--- a/lib/Echidna/Coverage.hs
+++ b/lib/Echidna/Coverage.hs
@@ -29,8 +29,8 @@ import Data.Set                   (Set, insert, size)
 import Data.Vector                (Vector, fromList)
 import Data.Vector.Generic        (maximumBy)
 import GHC.Generics
-import Crypto.Hash.SHA256         (hashlazy, hash)
-import System.Directory           (doesFileExist)
+import Crypto.Hash.SHA256         (hash)
+import System.Directory           (doesFileExist, createDirectoryIfMissing)
 
 import qualified Control.Monad.State.Strict as S
 import qualified Data.ByteString.Char8 as BS (pack, unpack)
@@ -117,6 +117,8 @@ hashString = BS.unpack . B16.encode . hash . BS.pack
 saveCalls :: [CoverageInfo] -> IO ()
 saveCalls cs = mapM_ f cs
   where f (c,m) = do
-          let filename = "txs/" ++ (hashString $ show m)
+          let dirname = "txs"
+          let filename = dirname ++ "/" ++ (hashString $ show m)
+          createDirectoryIfMissing False dirname
           b <- doesFileExist filename
           if (not b) then (writeFile filename $ displayAbiCall c ++ "\n") else return ()

--- a/package.yaml
+++ b/package.yaml
@@ -9,6 +9,7 @@ ghc-options: -Wall -fno-warn-orphans -O2
 dependencies:
   - aeson
   - base
+  - base16-bytestring
   - ansi-terminal
   - bytestring           >= 0.10.8 && < 0.11
   - containers           >= 0.5.7  && < 0.6
@@ -18,6 +19,7 @@ dependencies:
   - exceptions           >= 0.8.1  && < 0.9
   - hedgehog             >= 0.6
   - hevm
+  - cryptohash
   - lens                 >= 4.15.1 && < 4.16
   - mtl                  >= 2.2.1  && < 2.3
   - multiset             >= 0.3    && < 0.4

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -14,7 +14,7 @@ import Data.Text               (pack)
 import Data.Semigroup          ((<>))
 
 import Echidna.Config
-import Echidna.Coverage (ePropertySeqCoverage, getCover)
+import Echidna.Coverage (ePropertySeqCoverage, getCover, saveCalls)
 import Echidna.Exec
 import Echidna.Solidity
 
@@ -80,7 +80,9 @@ main = do
 
       replicateM_ (config ^. epochs) $ do
         xs <- liftIO $ forM tests $ \(x,y) -> swapMVar y [] <&> (, x, y) . getCover
-        checkGroup . Group (GroupName file) =<< mapM prop xs
+        _  <- checkGroup . Group (GroupName file) =<< mapM prop xs
+        ls <- liftIO $ mapM (readMVar . snd) tests
+        liftIO $ saveCalls $ concat ls
         
       ls <- liftIO $ mapM (readMVar . snd) tests
       let ci = foldl' (\acc xs -> unions (acc : map snd xs)) mempty ls


### PR DESCRIPTION
This patch enables Echidna to explore complex contract and save the unique transactions that it discovers acording to the coverage information in the "txs" directory. For instance, using this contract:

```solidity
contract C {
  bool state = true;
  function f(uint x, uint y, uint z) {
    require(x == 12);
    require(y == 8);
    require(z == 0);
    state = false;
    return;
  }

  function echidna_state() returns (bool) {
    return state;
  }
}
```
and this config:

```yaml
testLimit: 1000
epochs: 50
range: 1
printCoverage: true
```
Echidna produces the following files:

```bash
$ tail -f txs/*
==> txs/2fad4ca859d2beea328b4d89a3f6b3a0159d4ab5e2daac00b58e95101a9949b6 <==
f(83006518593401026877002066252139153289669799003303892805020259071083755513852,111789781830202758384157176293928937901288938685289627343970582402723635776859,85220154112604218682235745130937888514668036279708809103845409540750944322327)

==> txs/781ace0f6e8283543f318a3628ba5fd4ad6e06fe74efc9c2bda526b9a1c21e47 <==
f(12,8,19)

==> txs/ca3d96852f17358131206a92f2d70e252c8d906fab361180c0a01955b1b3fb59 <==
f(12,3,18)
```

Several Echidna instances can be run in parallel to accumulate more test cases in the same directory (however, they are not going to share information). Also, other tools could parse the transactions discovered and continue the exploration (e.g using symbolic execution).