### PR TITLE
Update hevm using nix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dapptools"]
+	path = dapptools
+	url = https://github.com/dapphub/dapptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
- - stack install hedgehog
+ - stack install lens
  #- stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ install:
  - ./.travis/install-stack.sh
 
 script:
- - git clone https://github.com/dapphub/dapptools --depth 1
  - echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 
 script:
  - nix-env -i stack
- #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
  - stack --no-terminal test --ghc-options="$GHC_OPTIONS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ script:
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
- - stack install hevm
- #- stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+ - stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,9 @@ script:
  - nix-env -i stack
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
- - |
-   set -ex
-   # Run tests
-   stack setup
-   stack --no-terminal test --ghc-options="$GHC_OPTIONS"
-   set +ex
+ - stack setup || true
+ - stack --no-terminal test --ghc-options="$GHC_OPTIONS" || true
+ - df -h
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
   fast_finish: true
   include:
     # Add build targets here
-    - env: GHCVER=8.2.1 CACHE_NAME=8.2.1 BUILD_BINARY=1
-    - env: GHCVER=8.2.1 CACHE_NAME=8.2.1-osx BUILD_BINARY=1
+    - env: BUILD_BINARY=1
+      os: linux
+    - env: BUILD_BINARY=1
       os: osx
 
 # workaround for a macOS specific issue with trusted users

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
   # Increase the size of ramdisk on sudo enabled infrastructure
   # https://github.com/travis-ci/travis-ci/issues/9036#issuecomment-357189213
   #- sudo mount -o remount,size=50% /var/ramfs
-  - rm -Rf $HOME/.ghc $HOME/.cabal $HOME/.stack
   - sudo mkdir -p /etc/nix
   # workaround for a macOS specific issue with trusted users
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ before_install:
   - sudo mkdir -p /etc/nix
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
-  - nix-collect-garbage
-  - nix-collect-garbage
 
 install:
  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
@@ -43,7 +41,7 @@ script:
    set -ex
    # Run tests
    stack setup
-   #stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+   stack --no-terminal test --ghc-options="$GHC_OPTIONS"
    set +ex
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ matrix:
 before_install:
   # Increase the size of ramdisk on sudo enabled infrastructure
   # https://github.com/travis-ci/travis-ci/issues/9036#issuecomment-357189213
-  - sudo mount -o remount,size=50% /var/ramfs
+  #- sudo mount -o remount,size=50% /var/ramfs
+  - rm -Rf $HOME/.ghc $HOME/.cabal $HOME/.stack
   - sudo mkdir -p /etc/nix
   # workaround for a macOS specific issue with trusted users
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ script:
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
- - stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+ - stack install readline
+ #- stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
   - sudo mkdir -p /etc/nix
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
+  - nix-collect-garbage
+  - nix-collect-garbage
 
 install:
  - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
@@ -33,6 +35,7 @@ install:
  - ./.travis/install-ghr.sh
 
 script:
+ - df -h
  - nix-env -i stack
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
@@ -40,7 +43,7 @@ script:
    set -ex
    # Run tests
    stack setup
-   stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+   #stack --no-terminal test --ghc-options="$GHC_OPTIONS"
    set +ex
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
         - $HOME/.cabal
         - $HOME/.stack
         - .stack-work
-        - /nix
+        #- /nix
     timeout: 1800
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,21 @@ matrix:
   include:
     # Add build targets here
     - env: GHCVER=8.2.1 CACHE_NAME=8.2.1 BUILD_BINARY=1
-      compiler: ": #stack 8.2.1"
+      #compiler: ": #stack 8.2.1"
     - env: GHCVER=8.2.1 CACHE_NAME=8.2.1-osx BUILD_BINARY=1
-           LDFLAGS=-L/usr/local/opt/readline/lib CFLAGS=-I/usr/local/opt/readline/include
+           #LDFLAGS=-L/usr/local/opt/readline/lib CFLAGS=-I/usr/local/opt/readline/include
       os: osx
-      compiler: ": #stack 8.2.1"
+      #compiler: ": #stack 8.2.1"
 
 install:
  - unset CC
  - export PATH=$HOME/.local/bin:$PATH
  - ./.travis/install-ghr.sh
- - ./.travis/install-stack.sh
+ #- ./.travis/install-stack.sh
 
 script:
- - echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - nix-env -i stack
+ #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - |
    set -ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 # Adapted from https://github.com/ChrisPenner/haskell-stack-travis-ci
 language: nix
 sudo: true
-git:
-  depth: 3
   
 cache:
     directories:
@@ -11,6 +9,7 @@ cache:
         - $HOME/.stack
         - .stack-work
         - /nix
+    timeout: 1800
 
 matrix:
   fast_finish: true
@@ -18,17 +17,12 @@ matrix:
     # Add build targets here
     - env: BUILD_BINARY=1
       os: linux
-    - env: BUILD_BINARY=1
-      os: osx
+    #- env: BUILD_BINARY=1
+    #  os: osx
 
 before_install:
-  # Increase the size of ramdisk on sudo enabled infrastructure
-  # https://github.com/travis-ci/travis-ci/issues/9036#issuecomment-357189213
-  - df -h || true
-  - mount || true
+  # Increase the size of /run/user ramdisk 
   - sudo mount -o remount,size=30% /run/user || true
-  - df -h || true
-  - mount || true
   - sudo mkdir -p /etc/nix
   # workaround for a macOS specific issue with trusted users
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
@@ -45,9 +39,8 @@ script:
  - nix-env -i stack
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
- - stack setup || true
- - stack --no-terminal test --ghc-options="$GHC_OPTIONS" || true
- - df -h
+ - stack setup
+ - stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
     # Add build targets here
     - env: BUILD_BINARY=1
       os: linux
-    - env: BUILD_BINARY=1
-      os: osx
+    #- env: BUILD_BINARY=1
+    #  os: osx
 
 # workaround for a macOS specific issue with trusted users
 before_install:
@@ -40,7 +40,7 @@ script:
    set -ex
    # Run tests
    stack setup
-   #stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+   stack --no-terminal test --ghc-options="$GHC_OPTIONS"
    set +ex
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,12 @@ matrix:
     - env: BUILD_BINARY=1
       os: osx
 
-# workaround for a macOS specific issue with trusted users
 before_install:
+  # Increase the size of ramdisk on sudo enabled infrastructure
+  # https://github.com/travis-ci/travis-ci/issues/9036#issuecomment-357189213
+  - sudo mount -o remount,size=50% /var/ramfs
   - sudo mkdir -p /etc/nix
+  # workaround for a macOS specific issue with trusted users
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,11 @@ matrix:
 before_install:
   # Increase the size of ramdisk on sudo enabled infrastructure
   # https://github.com/travis-ci/travis-ci/issues/9036#issuecomment-357189213
-  #- sudo mount -o remount,size=50% /var/ramfs
+  - df -h || true
+  - mount || true
+  - sudo mount -o remount,size=30% /run/user || true
+  - df -h || true
+  - mount || true
   - sudo mkdir -p /etc/nix
   # workaround for a macOS specific issue with trusted users
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
@@ -38,7 +42,6 @@ install:
  - ./.travis/install-ghr.sh
 
 script:
- - df -h
  - nix-env -i stack
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ script:
  - echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
+ # workaround for stack bug: https://github.com/commercialhaskell/stack/issues/2282#issuecomment-351285376
+ - rm -rf ~/.stack/setup-exe-cache
  - stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ script:
  - |
    set -ex
    # Run tests
-   stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+   stack setup
+   #stack --no-terminal test --ghc-options="$GHC_OPTIONS"
    set +ex
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
         - $HOME/.cabal
         - $HOME/.stack
         - .stack-work
+        - /nix
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
- - stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+ #- stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
- #- stack --no-terminal test --ghc-options="$GHC_OPTIONS"
+ - stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
         - $HOME/.cabal
         - $HOME/.stack
         - .stack-work
-        #- /nix
     timeout: 1800
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  - GHC_OPTIONS="-Werror"
  - stack setup
  # workaround for stack bug: https://github.com/commercialhaskell/stack/issues/2282#issuecomment-351285376
- - rm -rf ~/.stack/setup-exe-cache
+ - nix-collect-garbage
  - stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,21 @@ matrix:
   include:
     # Add build targets here
     - env: GHCVER=8.2.1 CACHE_NAME=8.2.1 BUILD_BINARY=1
-      #compiler: ": #stack 8.2.1"
     - env: GHCVER=8.2.1 CACHE_NAME=8.2.1-osx BUILD_BINARY=1
-           #LDFLAGS=-L/usr/local/opt/readline/lib CFLAGS=-I/usr/local/opt/readline/include
       os: osx
-      #compiler: ": #stack 8.2.1"
+
+# workaround for a macOS specific issue with trusted users
+before_install:
+  - sudo mkdir -p /etc/nix
+  - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 
 install:
+ - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+ - cachix use dapp
  - unset CC
  - export PATH=$HOME/.local/bin:$PATH
  - ./.travis/install-ghr.sh
- #- ./.travis/install-stack.sh
 
 script:
  - nix-env -i stack

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ install:
  - export PATH=$HOME/.local/bin:$PATH
  - ./.travis/install-ghr.sh
  - ./.travis/install-stack.sh
- - git clone https://github.com/dapphub/dapptools --depth 1
 
 script:
+ - git clone https://github.com/dapphub/dapptools --depth 1
  - echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
- - stack install readline
+ - stack install hedgehog
  #- stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # Adapted from https://github.com/ChrisPenner/haskell-stack-travis-ci
 language: nix
 sudo: true
-
+git:
+  depth: 3
+  
 cache:
     directories:
         - $HOME/.ghc
@@ -16,8 +18,8 @@ matrix:
     # Add build targets here
     - env: BUILD_BINARY=1
       os: linux
-    #- env: BUILD_BINARY=1
-    #  os: osx
+    - env: BUILD_BINARY=1
+      os: osx
 
 # workaround for a macOS specific issue with trusted users
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
  #- echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
  - stack setup
- - stack install lens
+ - stack install hevm
  #- stack --no-terminal test --ghc-options="$GHC_OPTIONS"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,11 @@ install:
  - export PATH=$HOME/.local/bin:$PATH
  - ./.travis/install-ghr.sh
  - ./.travis/install-stack.sh
+ - git clone https://github.com/dapphub/dapptools --depth 1
 
 script:
  - echo "$(stack ghc -- --version) [$(stack ghc -- --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - GHC_OPTIONS="-Werror"
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
-   stack install readline --extra-include-dirs=/usr/local/opt/readline/include
-                          --extra-lib-dirs=/usr/local/opt/readline/lib;
-   fi
  - |
    set -ex
    # Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 WORKDIR /home/tester
+COPY . /home/tester/echidna/
+WORKDIR /home/tester/echidna
+RUN chown -R user .
 USER tester
 ENV USER tester
 
-RUN curl https://nixos.org/nix/install | sh
-
-COPY . /home/tester/echidna/
-WORKDIR /home/tester/echidna
+RUN curl https://nixos.org/nix/install | sh 
 
 RUN    . /home/tester/.nix-profile/etc/profile.d/nix.sh \
     && nix-env -i stack \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM ubuntu:rolling
-RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y curl libgmp-dev libbz2-dev libreadline-dev software-properties-common locales-all locales
-RUN add-apt-repository -y ppa:ethereum/ethereum
-RUN apt-get update
-RUN apt-get install -y solc
-RUN curl -sSL https://get.haskellstack.org/ | sh
+RUN echo "build-users-group =" > /etc/nix/nix.conf
+RUN curl https://nixos.org/nix/install | sh
+RUN nix-env -i stack
 COPY . /echidna/
 WORKDIR /echidna
-RUN stack upgrade && stack setup && stack install
+RUN stack setup && stack install
 ENV PATH=$PATH:/root/.local/bin
 RUN update-locale LANG=en_US.UTF-8
 RUN locale-gen en_US.UTF-8  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
 FROM ubuntu:rolling
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y curl software-properties-common locales-all locales
-RUN mkdir -p /etc/nix
-RUN echo "build-users-group =" > /etc/nix/nix.conf
-RUN curl https://nixos.org/nix/install | sh
-RUN nix-env -i stack
-COPY . /echidna/
-WORKDIR /echidna
-RUN stack setup && stack install
-ENV PATH=$PATH:/root/.local/bin
-RUN update-locale LANG=en_US.UTF-8
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
+RUN apt-get install -y curl bzip2 gnupg perl bash sudo software-properties-common locales-all locales
+
+RUN useradd -m -d /home/tester -s /bin/bash tester
+RUN usermod -a -G sudo tester
+RUN echo " tester      ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
+
+WORKDIR /home/tester
+USER tester
+ENV USER tester
+
+RUN curl https://nixos.org/nix/install | sh
+
+COPY . /home/tester/echidna/
+WORKDIR /home/tester/echidna
+
+RUN . /home/tester/.nix-profile/etc/profile.d/nix.sh && \
+    nix-env -i stack && stack setup && stack install
+
+ENV PATH=$PATH:/home/tester/.local/bin
 CMD ["echidna-test", "solidity/cli.sol"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LC_ALL en_US.UTF-8
 WORKDIR /home/tester
 COPY . /home/tester/echidna/
 WORKDIR /home/tester/echidna
-RUN chown -R user .
+RUN chown -R tester .
 USER tester
 ENV USER tester
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:rolling
-RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y curl bzip2 gnupg perl bash sudo software-properties-common locales-all locales
+RUN    apt-get update \ 
+    && apt-get -y upgrade \
+    && apt-get install -y curl bzip2 gnupg perl bash sudo software-properties-common locales-all locales \
+    && useradd -m -d /home/tester -s /bin/bash tester \
+    && usermod -a -G sudo tester \
+    && echo " tester      ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen en_US.UTF-8
 
-RUN useradd -m -d /home/tester -s /bin/bash tester
-RUN usermod -a -G sudo tester
-RUN echo " tester      ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
-
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
-RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
@@ -20,8 +20,10 @@ RUN curl https://nixos.org/nix/install | sh
 COPY . /home/tester/echidna/
 WORKDIR /home/tester/echidna
 
-RUN . /home/tester/.nix-profile/etc/profile.d/nix.sh && \
-    nix-env -i stack && stack setup && stack install
+RUN    . /home/tester/.nix-profile/etc/profile.d/nix.sh \
+    && nix-env -i stack \
+    && stack setup \
+    && stack install
 
 ENV PATH=$PATH:/home/tester/.local/bin
 CMD ["echidna-test", "solidity/cli.sol"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:rolling
+RUN mkdir -p /etc/nix
 RUN echo "build-users-group =" > /etc/nix/nix.conf
 RUN curl https://nixos.org/nix/install | sh
 RUN nix-env -i stack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:rolling
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y curl software-properties-common locales-all locales
 RUN mkdir -p /etc/nix
 RUN echo "build-users-group =" > /etc/nix/nix.conf
 RUN curl https://nixos.org/nix/install | sh

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ This can be quite useful for playing around with the library.
 
 ## Docker Installation
 
-Set your Docker service to allow 4GB of RAM. Build the Dockerfile with the following command
+Set your Docker service to allow at least 4GB of RAM and do not forget to clone this repository with its submodules:
+
+`git clone https://github.com/trailofbits/echidna/ --recursive`
+
+Then, go into the `echidna` directory and build the Dockerfile with the following command:
 
 `docker build -t echidna .`
 

--- a/README.md
+++ b/README.md
@@ -12,38 +12,14 @@ It supports relatively sophisticated grammar-based fuzzing campaigns to falsify 
 
 ## Installation
 
-[stack](https://www.haskellstack.org/) is highly recommended to install echidna.
-If you are a particularly opinionated experienced Haskell user, cabal or hpack should work, but they are neither officially supported nor tested. 
 
-Before starting with it, make sure you have libgmp-dev installed otherwise ghc will fail to compile. Also, libbz2 and libreadline are required by some packages. For instance, in Ubuntu/Debian you can execute:
+To properly compile and install echidna we use [nix](https://nixos.org/nix/) to take care of every dependency. To install, just execute:
 
 ```
-# apt-get install libgmp-dev libbz2-dev libreadline-dev
-```
-
-[solc](https://www.npmjs.com/package/solc) is another echidna dependency not handled via stack.
-It is technically optional, but working with solidity source will fail without it.
-Install `solc` following the [official document](https://solidity.readthedocs.io/en/v0.4.24/installing-solidity.html).
-Note that `solc` must be installed by any method other than `npm / Node.js`.
-
-Once solc is installed, installing stack (`brew install haskell-stack`) and running
-
-```
-stack upgrade
+git clone https://github.com/trailofbits/echidna/ --recursive
+cd echidna
+nix-env -i stack
 stack setup
-stack install
-```
-
-from inside the echidna directory should be all that's needed.
-
-If you have weird problems involving `readline` on MacOS, try:
-
-```
-brew install readline
-brew link readline --force
-export LDFLAGS=-L/usr/local/opt/readline/lib
-export CPPFLAGS=-I/usr/local/opt/readline/include
-stack install readline --extra-include-dirs=/usr/local/opt/readline/include --extra-lib-dirs=/usr/local/opt/readline/lib
 stack install
 ```
 

--- a/dapptools.nix
+++ b/dapptools.nix
@@ -1,0 +1,20 @@
+{ghc}:
+
+let
+  # Import a specific Nixpkgs revision to use as the base for our overlay.
+  nixpkgs = (import <nixpkgs> {}).fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "4b649a99d8461c980e7028a693387dc48033c1f7";
+    sha256 = "0iy2gllj457052wkp20baigb2bnal9nhyai0z9hvjr3x25ngck4y";
+  };
+in
+
+  # Now return the Nixpkgs configured to use our overlay.
+  with ( import nixpkgs ({ overlays = [(import ./dapptools/overlay.nix)]; }));
+
+  haskell.lib.buildStackProject {
+  inherit ghc;
+  name = "echdina";
+  buildInputs = [ hevm git bzip2 ethjet secp256k1 readline zlib];
+  }

--- a/dapptools.nix
+++ b/dapptools.nix
@@ -16,5 +16,5 @@ in
   haskell.lib.buildStackProject {
   inherit ghc;
   name = "echdina";
-  buildInputs = [ git bzip2 ethjet secp256k1 readline zlib ];
+  buildInputs = [ git bzip2 ethjet secp256k1 readline zlib haskellPackages.happy ];
   }

--- a/dapptools.nix
+++ b/dapptools.nix
@@ -16,5 +16,5 @@ in
   haskell.lib.buildStackProject {
   inherit ghc;
   name = "echdina";
-  buildInputs = [ hevm git bzip2 ethjet secp256k1 readline zlib ];
+  buildInputs = [ git bzip2 ethjet secp256k1 readline zlib ];
   }

--- a/dapptools.nix
+++ b/dapptools.nix
@@ -16,5 +16,5 @@ in
   haskell.lib.buildStackProject {
   inherit ghc;
   name = "echdina";
-  buildInputs = [ hevm git bzip2 ethjet secp256k1 readline zlib];
+  buildInputs = [ hevm git bzip2 ethjet secp256k1 readline zlib ];
   }

--- a/package.yaml
+++ b/package.yaml
@@ -21,8 +21,8 @@ dependencies:
   - lens                 >= 4.15.1 && < 4.16
   - mtl                  >= 2.2.1  && < 2.3
   - multiset             >= 0.3    && < 0.4
-  - optparse-applicative >= 0.12.0 && < 0.14
-  - process              >= 1.4.3  && < 1.5
+  - optparse-applicative
+  - process
   - stm
   - temporary            >= 1.2.1  && < 1.3
   - text                 >= 1.2.2  && < 1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,7 +25,7 @@ extra-deps:
 - s-cargot-0.1.4.0
 - Unixutils-1.54.1
 - optparse-applicative-0.14.2.0
-- process-1.4.3.0
+- process-1.6.4.0
 - readline-1.0.3.0
 - time-1.6.0.1
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.15
+resolver: lts-10.0
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.15
+resolver: lts-11.0
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,8 @@ packages:
 - '.'
 
 extra-deps:
-- git: https://github.com/dapphub/hevm.git
-  commit: 40b4ce9d38ed711ffd6065e697807100b3f0a3c3
+- ./dapptools/src/hevm
+- ./dapptools/src/libethjet-haskell
 - brick-0.18
 - config-ini-0.2.1.1
 - data-clist-0.1.2.0
@@ -23,6 +23,7 @@ extra-deps:
 - tree-view-0.5
 - vty-5.16
 - word-wrap-0.4.1
+- s-cargot-0.1.4.0
 
 nix:
   enable: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.0
+resolver: lts-8.15
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,3 +23,7 @@ extra-deps:
 - tree-view-0.5
 - vty-5.16
 - word-wrap-0.4.1
+
+nix:
+  enable: true
+  shell-file: dapptools.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.0
+resolver: lts-10.0
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,6 @@ extra-deps:
 - HSH-2.1.3
 - ipprint-0.6
 - megaparsec-6.4.0
-- optparse-applicative-0.13.2.0
 - parser-combinators-0.4.0
 - restless-git-0.5.0
 - rosezipper-0.2
@@ -24,6 +23,11 @@ extra-deps:
 - vty-5.16
 - word-wrap-0.4.1
 - s-cargot-0.1.4.0
+- Unixutils-1.54.1
+- optparse-applicative-0.14.2.0
+- process-1.4.3.0
+- readline-1.0.3.0
+- time-1.6.0.1
 
 nix:
   enable: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,3 +32,4 @@ extra-deps:
 nix:
   enable: true
   shell-file: dapptools.nix
+  add-gc-roots: true


### PR DESCRIPTION
This PR implements the use of nix to upgrade hevm to the last revision (it's tagged as version 0.15) as well as install every dependency of echidna.
This PR disables the CI tests in OSX since they take a longer than 50 minutes to run: some nix packages are missing from the binary cache (e.g. python 3.6). OSX is still supported, but we disabled the CI tests to avoid timeouts.

To restore the OSX tests, it's necessary to compile the missing packages and upload them to a [cachix](https://github.com/cachix/cachix) instance.