### PR TITLE
Added checks to detect fatal errors of contracts

### DIFF
--- a/lib/Echidna/Exec.hs
+++ b/lib/Echidna/Exec.hs
@@ -115,7 +115,7 @@ instance Show (VMState v) where
 
 newtype VMAction (v :: * -> *) = 
   Call SolCall
- 
+
 instance Show (VMAction v) where
   show (Call c) = displayAbiCall c
 


### PR DESCRIPTION
Some contracts fail with fatal errors like self destruct or they will run out of stack when they are running in Echidna. This patch will make any property to automatically fail in these edge cases. It should fix #26.