### PR TITLE
Docker: Use ubuntu:bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu:bionic
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get install -y curl libgmp-dev libbz2-dev libreadline-dev software-properties-common locales-all locales
 RUN add-apt-repository -y ppa:ethereum/ethereum


### PR DESCRIPTION
The `rolling` tag currently points to `cosmic`, and there are no `solc` packages for it yet in the [`ethereum/ethereum` PPA](https://launchpad.net/~ethereum/+archive/ubuntu/ethereum).