### PR TITLE
Docker: run bash in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8  
 ENV LANGUAGE en_US:en  
 ENV LC_ALL en_US.UTF-8
-CMD ["echidna-test", "solidity/cli.sol"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
This allows users to run the container in their project directory and have their files available, without having to cd, by using -w `pwd`.