### PR TITLE
Support for solc 0.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,17 +36,14 @@ script:
  - STACK_OPTS="$STACK_OPTS --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib"
  - |
    set -ex
-   # Run tests using solc 0.4.25
-   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   cp ~/.local/bin/solc-0.4.25 ~/.local/bin/solc || true
-   stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
-   set +ex
- - |
-   set -ex
-   # Run tests using solc 0.5.4
-   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   cp ~/.local/bin/solc-0.5.4 ~/.local/bin/solc || true
-   stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
+   run_tests_using () {
+     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+     cp ~/.local/bin/$1 ~/.local/bin/solc || true
+     stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
+   }
+
+   run_tests_using "solc-0.4.25"
+   run_tests_using "solc-0.5.4"
    set +ex
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,19 @@ script:
  - STACK_OPTS="$STACK_OPTS --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib"
  - |
    set -ex
-   # Run tests
+   # Run tests using solc 0.4.25
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+   sudo /usr/bin/solc-0.4.25 /usr/bin/solc
    stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    set +ex
+ - |
+   set -ex
+   # Run tests using solc 0.5.4
+   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+   sudo /usr/bin/solc-0.5.4 /usr/bin/solc
+   stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
+   set +ex
+
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ script:
    set -ex
    # Run tests using solc 0.4.25
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   sudo /usr/bin/solc-0.4.25 /usr/bin/solc
+   cp ~/.local/bin/solc-0.4.25 /usr/bin/solc
    stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    set +ex
  - |
    set -ex
    # Run tests using solc 0.5.4
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   sudo /usr/bin/solc-0.5.4 /usr/bin/solc
+   cp ~/.local/bin/solc-0.5.4 /usr/bin/solc
    stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    set +ex
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ script:
    set -ex
    # Run tests using solc 0.4.25
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   cp ~/.local/bin/solc-0.4.25 ~/.local/bin/solc
+   cp ~/.local/bin/solc-0.4.25 ~/.local/bin/solc || true
    stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    set +ex
  - |
    set -ex
    # Run tests using solc 0.5.4
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   cp ~/.local/bin/solc-0.5.4 ~/.local/bin/solc
+   cp ~/.local/bin/solc-0.5.4 ~/.local/bin/solc || true
    stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    set +ex
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ script:
    set -ex
    # Run tests using solc 0.4.25
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   cp ~/.local/bin/solc-0.4.25 /usr/bin/solc
+   cp ~/.local/bin/solc-0.4.25 ~/.local/bin/solc
    stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    set +ex
  - |
    set -ex
    # Run tests using solc 0.5.4
    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-   cp ~/.local/bin/solc-0.5.4 /usr/bin/solc
+   cp ~/.local/bin/solc-0.5.4 ~/.local/bin/solc
    stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    set +ex
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,9 @@ script:
  - STACK_OPTS="$STACK_OPTS --extra-include-dirs=/usr/local/include --extra-lib-dirs=/usr/local/lib"
  - |
    set -ex
+   export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+   
    run_tests_using () {
-     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
      cp ~/.local/bin/$1 ~/.local/bin/solc || true
      stack --no-terminal test --ghc-options="$GHC_OPTIONS" $STACK_OPTS
    }

--- a/.travis/install-solc.sh
+++ b/.travis/install-solc.sh
@@ -15,7 +15,10 @@ fetch_stack_linux() {
   rm -Rf solc-static-linux;
   wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux;
   chmod +x solc-static-linux;
-  mv solc-static-linux ~/.local/bin/solc;
+  mv solc-static-linux ~/.local/bin/solc-0.4.25;
+  wget https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux;
+  chmod +x solc-static-linux;
+  mv solc-static-linux ~/.local/bin/solc-0.5.4;
 }
 
 if [ "$(uname)" != "Darwin" ]; then

--- a/examples/solidity/bad/nobytecode.sol
+++ b/examples/solidity/bad/nobytecode.sol
@@ -1,5 +1,3 @@
-//pragma solidity ^0.4.24;
-
 contract Abstract {
   function nothere() pure public {}
   function echidna_nothere() pure public {}

--- a/examples/solidity/bad/nobytecode.sol
+++ b/examples/solidity/bad/nobytecode.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+//pragma solidity ^0.4.24;
 
 contract Abstract {
   function nothere() pure public {}

--- a/examples/solidity/bad/nocontract.sol
+++ b/examples/solidity/bad/nocontract.sol
@@ -1,5 +1,3 @@
-//pragma solidity ^0.4.24;
-
 contract Abstract {
   function nothere() pure public {}
   function echidna_nothere() pure public {}

--- a/examples/solidity/bad/nocontract.sol
+++ b/examples/solidity/bad/nocontract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+//pragma solidity ^0.4.24;
 
 contract Abstract {
   function nothere() pure public {}

--- a/examples/solidity/bad/nofuncs.sol
+++ b/examples/solidity/bad/nofuncs.sol
@@ -1,3 +1,1 @@
-//pragma solidity ^0.4.24;
-
 contract Abstract {}

--- a/examples/solidity/bad/nofuncs.sol
+++ b/examples/solidity/bad/nofuncs.sol
@@ -1,3 +1,3 @@
-pragma solidity ^0.4.24;
+//pragma solidity ^0.4.24;
 
 contract Abstract {}

--- a/examples/solidity/bad/notests.sol
+++ b/examples/solidity/bad/notests.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+//pragma solidity ^0.4.24;
 
 contract Abstract {
   function f() pure public returns (int) {return 0;}

--- a/examples/solidity/bad/notests.sol
+++ b/examples/solidity/bad/notests.sol
@@ -1,5 +1,3 @@
-//pragma solidity ^0.4.24;
-
 contract Abstract {
   function f() pure public returns (int) {return 0;}
 }

--- a/examples/solidity/bad/onlytests.sol
+++ b/examples/solidity/bad/onlytests.sol
@@ -1,5 +1,3 @@
-//pragma solidity ^0.4.24;
-
 contract Abstract {
   function echidna_f() pure public returns (int) {return 0;}
 }

--- a/examples/solidity/bad/onlytests.sol
+++ b/examples/solidity/bad/onlytests.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+//pragma solidity ^0.4.24;
 
 contract Abstract {
   function echidna_f() pure public returns (int) {return 0;}

--- a/examples/solidity/bad/testargs.sol
+++ b/examples/solidity/bad/testargs.sol
@@ -1,5 +1,3 @@
-//pragma solidity ^0.4.24;
-
 contract Abstract {
   function f() pure public {}
   function echidna_f(int x) pure public returns (int) {return 0;}

--- a/examples/solidity/bad/testargs.sol
+++ b/examples/solidity/bad/testargs.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+//pragma solidity ^0.4.24;
 
 contract Abstract {
   function f() pure public {}

--- a/examples/solidity/basic/flags.sol
+++ b/examples/solidity/basic/flags.sol
@@ -1,19 +1,19 @@
-pragma solidity ^0.4.16;
+//pragma solidity ^0.4.16;
 
 contract Test {
   bool private flag0=true;
   bool private flag1=true;
 
-  function set0(int val) returns (bool){
+  function set0(int val) public returns (bool){
     if (val % 100 == 0) {flag0 = false;}
   }
-  function set1(int val) returns (bool){
+  function set1(int val) public returns (bool){
     if (val % 10 == 0 && !flag0) {flag1 = false;}
   }
-  function echidna_alwaystrue() returns (bool){
+  function echidna_alwaystrue() public returns (bool){
     return(true);
   }
-  function echidna_sometimesfalse() returns (bool){
+  function echidna_sometimesfalse() public returns (bool){
     return(flag1);
   }
 }

--- a/examples/solidity/basic/flags.sol
+++ b/examples/solidity/basic/flags.sol
@@ -1,5 +1,3 @@
-//pragma solidity ^0.4.16;
-
 contract Test {
   bool private flag0=true;
   bool private flag1=true;

--- a/examples/solidity/basic/killed.sol
+++ b/examples/solidity/basic/killed.sol
@@ -1,5 +1,3 @@
-pragma solidity ^0.4.16;
-
 contract C {
 
   uint private state = 0;

--- a/examples/solidity/basic/multisender.sol
+++ b/examples/solidity/basic/multisender.sol
@@ -3,27 +3,27 @@ contract C {
   bool state2 = false;
   bool state3 = false;
   
-  function s1() {
+  function s1() public {
     //require(x == msg.sender);
-    require(msg.sender == 0x1);
+    require(msg.sender == address(0x1));
     state1 = true;
   }
 
 
-  function s2() {
+  function s2() public {
     //require(x == msg.sender);
-    require(msg.sender == 0x2);
+    require(msg.sender == address(0x2));
     state2 = true;
   }
 
 
-  function s3() {
+  function s3() public {
     //require(x == msg.sender);
-    require(msg.sender == 0x3);
+    require(msg.sender == address(0x3));
     state3 = true;
   }
 
-  function echidna_all_sender() returns (bool) {
+  function echidna_all_sender() public returns (bool) {
     return (!state1 || !state2 || !state3);
   }
 

--- a/examples/solidity/basic/revert.sol
+++ b/examples/solidity/basic/revert.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.16;
+//pragma solidity ^0.4.16;
 
 contract C {
 

--- a/examples/solidity/basic/revert.sol
+++ b/examples/solidity/basic/revert.sol
@@ -1,5 +1,3 @@
-//pragma solidity ^0.4.16;
-
 contract C {
 
   int private state = 0;


### PR DESCRIPTION
Echidna was already working fine with Solidity 0.5.4. This PR fixes the testing contracts and adds the use of newer solidity version in the CI scripts.